### PR TITLE
theme_base: Remove pix_url and hide sectionname

### DIFF
--- a/layout/embedded.php
+++ b/layout/embedded.php
@@ -26,7 +26,7 @@ echo $OUTPUT->doctype(); ?>
 <html <?php echo $OUTPUT->htmlattributes() ?>>
 <head>
     <title><?php echo $PAGE->title ?></title>
-    <link rel="shortcut icon" href="<?php echo $OUTPUT->pix_url('favicon', 'theme')?>" />
+    <link rel="shortcut icon" href="<?php echo $OUTPUT->image_url('favicon', 'theme')?>" />
     <?php echo $OUTPUT->standard_head_html() ?>
 </head>
 <body id="<?php p($PAGE->bodyid) ?>" class="<?php p($PAGE->bodyclasses) ?>">

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -54,7 +54,7 @@ echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes() ?>>
 <head>
     <title><?php echo $PAGE->title ?></title>
-    <link rel="shortcut icon" href="<?php echo $OUTPUT->pix_url('favicon', 'theme')?>" />
+    <link rel="shortcut icon" href="<?php echo $OUTPUT->image_url('favicon', 'theme')?>" />
     <meta name="description" content="<?php p(strip_tags(format_text($SITE->summary, FORMAT_HTML))) ?>" />
     <?php echo $OUTPUT->standard_head_html() ?>
 </head>

--- a/layout/general.php
+++ b/layout/general.php
@@ -69,7 +69,7 @@ echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes() ?>>
 <head>
     <title><?php echo $PAGE->title ?></title>
-    <link rel="shortcut icon" href="<?php echo $OUTPUT->pix_url('favicon', 'theme')?>" />
+    <link rel="shortcut icon" href="<?php echo $OUTPUT->image_url('favicon', 'theme')?>" />
     <?php echo $OUTPUT->standard_head_html() ?>
 </head>
 <body id="<?php p($PAGE->bodyid) ?>" class="<?php p($PAGE->bodyclasses.' '.join(' ', $bodyclasses)) ?>">

--- a/layout/report.php
+++ b/layout/report.php
@@ -54,7 +54,7 @@ echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes() ?>>
 <head>
     <title><?php echo $PAGE->title ?></title>
-    <link rel="shortcut icon" href="<?php echo $OUTPUT->pix_url('favicon', 'theme')?>" />
+    <link rel="shortcut icon" href="<?php echo $OUTPUT->image_url('favicon', 'theme')?>" />
     <?php echo $OUTPUT->standard_head_html() ?>
 </head>
 <body id="<?php p($PAGE->bodyid) ?>" class="<?php p($PAGE->bodyclasses.' '.join(' ', $bodyclasses)) ?>">

--- a/style/course.css
+++ b/style/course.css
@@ -32,6 +32,10 @@
     margin-left: .2em;
 }
 
+.hidden.sectionname {
+    visibility: hidden;
+}
+
 .dir-rtl .section_add_menus .urlselect select {
     margin-right: .2em;
     margin-left: 0;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2016052300; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2017091800; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2016051900; // Requires this Moodle version.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->component = 'theme_base'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
This replaces the deprecated pix_url function and use the new image_url function. This also fixes the duplicate section name being displayed, by adding a CSS to target .hidden.sectionname. This should fix the child_theme theme_canvas as well.

![screenshot_2017-09-17_15-42-36](https://user-images.githubusercontent.com/16247613/30531400-39fbde88-9c8d-11e7-8a7c-3e45bbe6f610.png)
